### PR TITLE
View Navigation: using delta mouse movement (instead of force mouse warping)

### DIFF
--- a/source/blender/windowmanager/WM_types.h
+++ b/source/blender/windowmanager/WM_types.h
@@ -134,7 +134,6 @@ struct ImBuf;
 								 * and don't make sense to be accessed from the
 								 * search menu, even if poll() returns TRUE.
 								 * currently only used for the search toolbox */
-#define OPTYPE_CURSOR_WRAP	128	/* force mouse to wrap around */
 
 /* context to call operator in for WM_operator_name_call */
 /* rna_ui.c contains EnumPropertyItem's of these, keep in sync */

--- a/source/blender/windowmanager/intern/wm_event_system.c
+++ b/source/blender/windowmanager/intern/wm_event_system.c
@@ -1042,14 +1042,12 @@ static int wm_operator_invoke(bContext *C, wmOperatorType *ot, wmEvent *event,
 				int wrap;
 
 				if (op->opm) {
-					wrap = ((U.uiflag & USER_CONTINUOUS_MOUSE) &&
-					       ((op->opm->flag & OP_GRAB_POINTER) || (op->opm->type->flag & OPTYPE_GRAB_POINTER))) ||
-					       (op->opm->type->flag & OPTYPE_CURSOR_WRAP);
+					wrap = (U.uiflag & USER_CONTINUOUS_MOUSE) &&
+					       ((op->opm->flag & OP_GRAB_POINTER) || (op->opm->type->flag & OPTYPE_GRAB_POINTER));
 				}
 				else {
-					wrap = ((U.uiflag & USER_CONTINUOUS_MOUSE) &&
-					       ((op->flag & OP_GRAB_POINTER) || (ot->flag & OPTYPE_GRAB_POINTER))) ||
-					       (ot->flag & OPTYPE_CURSOR_WRAP);
+					wrap = (U.uiflag & USER_CONTINUOUS_MOUSE) &&
+					       ((op->flag & OP_GRAB_POINTER) || (ot->flag & OPTYPE_GRAB_POINTER));
 				}
 
 				/* exception, cont. grab in header is annoying */


### PR DESCRIPTION
@ideasman42 this is supposed to fix the things for linux. However the result is slightly different from what I get in OSX with the OPTYPE_CURSOR_WRAP.

It's subtle but opening a Blender build side -by-side of each branch (fps and fps-cursor-warp) shows that fps (with OPTYPE_CURSOR_WRAP) is more smooth.
