### PR TITLE
Update ui_previews_dynamic_enum.py

### DIFF
--- a/release/scripts/templates_py/ui_previews_dynamic_enum.py
+++ b/release/scripts/templates_py/ui_previews_dynamic_enum.py
@@ -40,7 +40,8 @@ def enum_previews_from_directory_items(self, context):
         return pcoll.my_previews
 
     print("Scanning directory: %s" % directory)
-
+    # Get absolute path from Blender relative path
+    directory = bpy.path.abspath(directory) 
     if directory and os.path.exists(directory):
         # Scan the directory for png files
         image_paths = []


### PR DESCRIPTION
It seems that Python module os does not work with Blender relative path, so converting to absolute path solves my problem. I am using Windows 10 with Blender 3.3.1.

This repository is only used as a mirror of git.blender.org. Blender development happens on
https://developer.blender.org.

To get started with contributing code, please see:
https://wiki.blender.org/wiki/Process/Contributing_Code
